### PR TITLE
Fix instruction misspelling

### DIFF
--- a/reex-ast/src/compiler/custom.rs
+++ b/reex-ast/src/compiler/custom.rs
@@ -149,15 +149,15 @@ define_blocks! {
         let mut c = 0;
         let mut inner_data = compiler.compile_blocks(block.item.as_ref());
         for block in &mut inner_data {
-            for instrution in block {
-                if let Instruction::Marker("selection_start", _) = instrution {
+            for instruction in block {
+                if let Instruction::Marker("selection_start", _) = instruction {
                     let id = c;
                     c += 1;
-                    *instrution = Instruction::StartSelection(id);
+                    *instruction = Instruction::StartSelection(id);
                 }
 
-                if let Instruction::Marker("selection_end", _) = instrution {
-                    *instrution = Instruction::EndSelection;
+                if let Instruction::Marker("selection_end", _) = instruction {
+                    *instruction = Instruction::EndSelection;
                 }
             }
         }


### PR DESCRIPTION
Instruction was misspelled as instrution when mass renaming in 11334b39f7b859f160c250f915f409f4328fb958.